### PR TITLE
Draft: sbs prefix header

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,32 +21,32 @@ checking.
 
 A quick reference for those familiar with the SDS API:
 
-| SDS               | SBS                           | Additional Info                                               |
-| ----------------- | ----------------------------- | ------------------------------------------------------------- |
-| `sdsnewlen`       | `sbsnewlen`/`SBSNEWLEN`       | -                                                             |
-| `sdsnew`          | `sbsnew`/`SBSNEW`             | -                                                             |
-| `sdsempty`        | `sbsempty`/`SBSEMPTY`         | -                                                             |
-| `sdsdup`          | `sbsdup`/`SBSDUP`             | -                                                             |
-| `sdslen`          | `sbslen`                      | -                                                             |
-| `sdsfree`         | ❌                            | No resource management                                        |
-| `sdscatlen`       | `sbscatlen`                   | -                                                             |
-| `sdscat`          | `sbscat`                      | -                                                             |
-| `sdscatsds`       | `sbscatsbs`                   | -                                                             |
-| `sdsgrowzero`     | `sbsresize`/`SBSRESIZE`       | Provides a new buffer & the extra buffer space is not zero'ed |
-| `sdscatprintf`    | `sbscatprintf`                | -                                                             |
-| `sdscatvprintf`   | `sbscatvprintf`               | -                                                             |
-| `sdscatfmt`       | `sbscatfmt`                   | -                                                             |
-| `sdsfromlonglong` | `sbsfromlonglong`/`SBSFROMLL` | -                                                             |
-| `sdstrim`         | `sbstrim`                     | -                                                             |
-| `sdsrange`        | `sbsrange`                    | -                                                             |
-| `sdscpylen`       | `sbscpylen`                   | -                                                             |
-| `sdscpy`          | `sbscpy`                      | -                                                             |
-| `sdscatrepr`      | `sbscatrepr`                  | -                                                             |
-| `sdssplitlen`     | ❌                            | May later be added via an iterator?                           |
-| `sdsfreesplitres` | ❌                            | No resource management                                        |
-| `sdssplitargs`    | ❌                            | May later be added via an iterator?                           |
-| `sdsjoin`         | `sbsjoin`                     | -                                                             |
-| `sdsjoinsds`      | `sbsjoinsbs`                  | -                                                             |
+| SDS               | SBS                           | Additional Info                     |
+| ----------------- | ----------------------------- | ----------------------------------- |
+| `sdsnewlen`       | `sbsnewlen`/`SBSNEWLEN`       | -                                   |
+| `sdsnew`          | `sbsnew`/`SBSNEW`             | -                                   |
+| `sdsempty`        | `sbsempty`/`SBSEMPTY`         | -                                   |
+| `sdsdup`          | `sbsdup`/`SBSDUP`             | -                                   |
+| `sdslen`          | `sbslen`                      | -                                   |
+| `sdsfree`         | ❌                            | No resource management              |
+| `sdscatlen`       | `sbscatlen`                   | -                                   |
+| `sdscat`          | `sbscat`                      | -                                   |
+| `sdscatsds`       | `sbscatsbs`                   | -                                   |
+| `sdsgrowzero`     | ❌                            | No need for resizing                |
+| `sdscatprintf`    | `sbscatprintf`                | -                                   |
+| `sdscatvprintf`   | `sbscatvprintf`               | -                                   |
+| `sdscatfmt`       | `sbscatfmt`                   | -                                   |
+| `sdsfromlonglong` | `sbsfromlonglong`/`SBSFROMLL` | -                                   |
+| `sdstrim`         | `sbstrim`                     | -                                   |
+| `sdsrange`        | `sbsrange`                    | -                                   |
+| `sdscpylen`       | `sbscpylen`                   | -                                   |
+| `sdscpy`          | `sbscpy`                      | -                                   |
+| `sdscatrepr`      | `sbscatrepr`                  | -                                   |
+| `sdssplitlen`     | ❌                            | May later be added via an iterator? |
+| `sdsfreesplitres` | ❌                            | No resource management              |
+| `sdssplitargs`    | ❌                            | May later be added via an iterator? |
+| `sdsjoin`         | `sbsjoin`                     | -                                   |
+| `sdsjoinsds`      | `sbsjoinsbs`                  | -                                   |
 
 ## Error Recovery
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ checking.
 ## Differences from SDS
 
 - No heap allocation
-- String must be accessed via `sbsstr()`
 - sbs struct is mutated instead of returning a new struct
 
 ## SDS API Mapping
@@ -61,8 +60,9 @@ failed malloc.
 It is recommended that for creating new SBS strings that you use the built-in
 macros. These macros not only reduce boilerplate code, but also ensure that a
 buffer is not accidentally shared between multiple sbs structs. These macros
-rely on compound literals to allow the creation of anonymous structs on the
-stack.
+rely on
+[compound literals](https://gcc.gnu.org/onlinedocs/gcc/Compound-Literals.html)
+to allow the creation of anonymous structs on the stack.
 
 The preferred way for strings is using `SBSNEW()` or one of the preset sizes
 `SBS64()`/`SBS128()`/`SBS256()`/`SBS512()`/`SBS1024()`/`SBS2048()`.
@@ -70,12 +70,12 @@ The preferred way for strings is using `SBSNEW()` or one of the preset sizes
 ✅ Best Way
 
 ```c
-sbs* text1 = SBSNEW("so short to write", 64); // the size must be a literal
-sbs* text2 = SBS64("even shorter");
-sbs* text3 = SBS2048("bigger buffer");
+sbs text1 = SBSNEW("so short to write", 64); // the size must be a literal
+sbs text2 = SBS64("even shorter");
+sbs text3 = SBS2048("bigger buffer");
 
 char raw_data[] = {65, 65, 0x0, 0x2};
-sbs* data = SBSNEWLEN(raw_data, sizeof(raw_data), 64);
+sbs data = SBSNEWLEN(raw_data, sizeof(raw_data), 64);
 ```
 
 ⛔️ Bad Way
@@ -83,20 +83,18 @@ sbs* data = SBSNEWLEN(raw_data, sizeof(raw_data), 64);
 ```c
 // exposes the internal buffer, making it easy to accidentally reuse
 char buffer[64];
-sbs text; // all functions prefer the pointer as the value
-sbsnew(&text, "so much boilerplate", buffer, sizeof(buffer));
+ // all functions prefer the pointer as the value
+sbs text; = sbsnew(&text, "so much boilerplate", buffer, sizeof(buffer));
 ```
 
-The creation functions all return either `sbs*` or `NULL` if there is a failure.
+The creation functions all return either `sbs` or `NULL` if there is a failure.
 This is perhaps the only place a segfault may occur if you do not do a `NULL`
 check in scenarios where initialization will fail.
 
 ## Properties
 
-Although the structure is transparent, it is best practice to prefer the
-property functions.
+These provide information about the sbs string.
 
-- `sbsstr()`: returns the c string/bytes
 - `sbslen()`: returns the length of the c string/bytes
 - `sbssize()`: returns the size of the buffer
 - `sbsavail()`: returns the amount of space left in the buffer.

--- a/sbs.c
+++ b/sbs.c
@@ -46,23 +46,23 @@ sbs sbsdup(sbs s, char buffer[], size_t buffer_size) {
   return sbsnewlen(h->str, h->len, buffer, buffer_size);
 }
 
-void sbsupdatelen(sbs str) {
-  sbshdr *h = to_sbshdr(str);
+void sbsupdatelen(sbs s) {
+  sbshdr *h = to_sbshdr(s);
   h->len = strlen(h->str);
 }
 
-void sbsclear(sbs str) {
-  sbshdr *h = to_sbshdr(str);
+void sbsclear(sbs s) {
+  sbshdr *h = to_sbshdr(s);
   h->len = 0;
   SBS_NULLTERM(h);
 }
 
-int sbscatlen(sbs str, const void *t, size_t len) {
-  sbshdr *h = to_sbshdr(str);
-  if (len >= sbsavail(str)) {
+int sbscatlen(sbs s, const void *t, size_t len) {
+  sbshdr *h = to_sbshdr(s);
+  if (len >= sbsavail(s)) {
     return -1;
   }
-  memcpy(sbsend(str), t, len);
+  memcpy(sbsend(s), t, len);
   h->len += len;
   SBS_NULLTERM(h);
   return 0;
@@ -70,13 +70,13 @@ int sbscatlen(sbs str, const void *t, size_t len) {
 
 int sbscat(sbs s, const char *t) { return sbscatlen(s, t, strlen(t)); }
 
-int sbscatsbs(sbs s, const sbs tstr) {
-  sbshdr *t = to_sbshdr(tstr);
-  return sbscatlen(s, t->str, t->len);
+int sbscatsbs(sbs s, const sbs t) {
+  sbshdr *th = to_sbshdr(t);
+  return sbscatlen(s, th->str, th->len);
 }
 
-int sbscpylen(sbs str, const char *t, size_t len) {
-  sbshdr *h = to_sbshdr(str);
+int sbscpylen(sbs s, const char *t, size_t len) {
+  sbshdr *h = to_sbshdr(s);
   if (len >= h->size) {
     return -1;
   }
@@ -90,10 +90,10 @@ int sbscpy(sbs s, const char *t) { return sbscpylen(s, t, strlen(t)); }
 
 #ifndef SBS_NO_FORMAT
 /* Like sbscatprintf() but gets va_list instead of being variadic. */
-int sbscatvprintf(sbs str, const char *fmt, va_list ap) {
-  sbshdr *h = to_sbshdr(str);
-  size_t bufsize = sbsavail(str);
-  int n = vsnprintf(sbsend(str), bufsize, fmt, ap);
+int sbscatvprintf(sbs s, const char *fmt, va_list ap) {
+  sbshdr *h = to_sbshdr(s);
+  size_t bufsize = sbsavail(s);
+  int n = vsnprintf(sbsend(s), bufsize, fmt, ap);
   if (n >= bufsize) {
     SBS_NULLTERM(h);
     return -1;
@@ -113,13 +113,13 @@ int sbscatprintf(sbs s, const char *fmt, ...) {
 }
 #endif
 
-void sbstrim(sbs str, const char *cset) {
-  sbshdr *h = to_sbshdr(str);
+void sbstrim(sbs s, const char *cset) {
+  sbshdr *h = to_sbshdr(s);
   char *start, *end, *sp, *ep;
   size_t len;
 
   sp = start = h->str;
-  ep = end = h->str + sbslen(str) - 1;
+  ep = end = h->str + sbslen(s) - 1;
   while (sp <= end && strchr(cset, *sp)) sp++;
   while (ep > sp && strchr(cset, *ep)) ep--;
   len = (sp > ep) ? 0 : ((ep - sp) + 1);
@@ -128,9 +128,9 @@ void sbstrim(sbs str, const char *cset) {
   SBS_NULLTERM(h);
 }
 
-void sbsrange(sbs str, ssize_t start, ssize_t end) {
-  sbshdr *h = to_sbshdr(str);
-  size_t newlen, len = sbslen(str);
+void sbsrange(sbs s, ssize_t start, ssize_t end) {
+  sbshdr *h = to_sbshdr(s);
+  size_t newlen, len = sbslen(s);
 
   if (len == 0) return;
   if (start < 0) {
@@ -158,25 +158,25 @@ void sbsrange(sbs str, ssize_t start, ssize_t end) {
 }
 
 /* Apply tolower() to every character of the sbs string 's'. */
-void sbstolower(sbs str) {
-  sbshdr *h = to_sbshdr(str);
-  for (size_t j = 0; j < sbslen(str); j++) h->str[j] = (char)tolower(h->str[j]);
+void sbstolower(sbs s) {
+  sbshdr *h = to_sbshdr(s);
+  for (size_t j = 0; j < sbslen(s); j++) h->str[j] = (char)tolower(h->str[j]);
 }
 
 /* Apply tolower() to every character of the sbs string 's'. */
-void sbstoupper(sbs str) {
-  sbshdr *h = to_sbshdr(str);
-  for (size_t j = 0; j < sbslen(str); j++) h->str[j] = (char)toupper(h->str[j]);
+void sbstoupper(sbs s) {
+  sbshdr *h = to_sbshdr(s);
+  for (size_t j = 0; j < sbslen(s); j++) h->str[j] = (char)toupper(h->str[j]);
 }
 
-int sbscmp(const sbs str1, const sbs str2) {
-  sbshdr *h1 = to_sbshdr(str1);
-  sbshdr *h2 = to_sbshdr(str2);
+int sbscmp(const sbs s1, const sbs s2) {
+  sbshdr *h1 = to_sbshdr(s1);
+  sbshdr *h2 = to_sbshdr(s2);
   size_t l1, l2, minlen;
   int cmp;
 
-  l1 = sbslen(str1);
-  l2 = sbslen(str2);
+  l1 = sbslen(s1);
+  l2 = sbslen(s2);
   minlen = (l1 < l2) ? l1 : l2;
   cmp = memcmp(h1->str, h2->str, minlen);
   if (cmp == 0) return l1 > l2 ? 1 : (l1 < l2 ? -1 : 0);
@@ -192,9 +192,9 @@ int sbscmp(const sbs str1, const sbs str2) {
  *
  * The function returns the sbs string pointer, that is always the same
  * as the input pointer since no resize is needed. */
-void sbsmapchars(sbs str, const char *from, const char *to, size_t setlen) {
-  size_t j, i, l = sbslen(str);
-  sbshdr *h = to_sbshdr(str);
+void sbsmapchars(sbs s, const char *from, const char *to, size_t setlen) {
+  size_t j, i, l = sbslen(s);
+  sbshdr *h = to_sbshdr(s);
   for (j = 0; j < l; j++) {
     for (i = 0; i < setlen; i++) {
       if (h->str[j] == from[i]) {
@@ -284,15 +284,15 @@ sbs sbsfromlonglong(char buffer[64], long long value) {
 
 /* Join an array of C strings using the specified separator (also a C string).
  * Returns the result as an sbs string. */
-int sbsjoin(sbs str, const char **argv, int argc, const char *sep) {
-  sbshdr *h = to_sbshdr(str);
+int sbsjoin(sbs s, const char **argv, int argc, const char *sep) {
+  sbshdr *h = to_sbshdr(s);
   int j;
   sbshdr backup = *h;
 
   for (j = 0; j < argc; j++) {
-    SBS_CATCH(sbscat(str, argv[j]), goto fail);
+    SBS_CATCH(sbscat(s, argv[j]), goto fail);
     if (j != argc - 1) {
-      SBS_CATCH(sbscat(str, sep), goto fail);
+      SBS_CATCH(sbscat(s, sep), goto fail);
     }
   }
   return 0;
@@ -302,17 +302,17 @@ fail:
   return -1;
 }
 
-int sbsjoinsbs(sbs str, const sbs argv[], int argc, const char *sep,
+int sbsjoinsbs(sbs s, const sbs argv[], int argc, const char *sep,
                size_t seplen) {
   int j;
 
-  sbshdr *h = to_sbshdr(str);
+  sbshdr *h = to_sbshdr(s);
   sbshdr backup = *h;
 
   for (j = 0; j < argc; j++) {
-    SBS_CATCH(sbscatsbs(str, argv[j]), goto fail);
+    SBS_CATCH(sbscatsbs(s, argv[j]), goto fail);
     if (j != argc - 1) {
-      SBS_CATCH(sbscatlen(str, sep, seplen), goto fail);
+      SBS_CATCH(sbscatlen(s, sep, seplen), goto fail);
     }
   }
   return 0;
@@ -322,8 +322,8 @@ fail:
   return -1;
 }
 #ifndef SBS_NO_FORMAT
-static int sbscatvfmt(sbs str, char const *fmt, va_list ap) {
-  sbshdr *h = to_sbshdr(str);
+static int sbscatvfmt(sbs s, char const *fmt, va_list ap) {
+  sbshdr *h = to_sbshdr(s);
   sbshdr backup = *h;
   const char *f = fmt;
 
@@ -341,12 +341,12 @@ static int sbscatvfmt(sbs str, char const *fmt, va_list ap) {
         switch (next) {
           case 's': {
             str2 = va_arg(ap, char *);
-            SBS_CATCH(sbscat(str, str2), goto fail);
+            SBS_CATCH(sbscat(s, str2), goto fail);
             break;
           }
           case 'S': {
             sbs tmp_sbs = va_arg(ap, sbs);
-            SBS_CATCH(sbscatsbs(str, tmp_sbs), goto fail);
+            SBS_CATCH(sbscatsbs(s, tmp_sbs), goto fail);
             break;
           }
           case 'i':
@@ -358,7 +358,7 @@ static int sbscatvfmt(sbs str, char const *fmt, va_list ap) {
             {
               char numbuf[SBS_LLSTR_SIZE];
               l = sbsll2str(numbuf, num);
-              SBS_CATCH(sbscatlen(str, numbuf, l), goto fail);
+              SBS_CATCH(sbscatlen(s, numbuf, l), goto fail);
               break;
             }
             break;
@@ -371,18 +371,18 @@ static int sbscatvfmt(sbs str, char const *fmt, va_list ap) {
             {
               char numbuf[SBS_LLSTR_SIZE];
               l = sbsull2str(numbuf, unum);
-              SBS_CATCH(sbscatlen(str, numbuf, l), goto fail);
+              SBS_CATCH(sbscatlen(s, numbuf, l), goto fail);
               break;
             }
             break;
           default: { /* Handle %% and generally %<unknown>. */
-            SBS_CATCH(sbscatlen(str, &next, 1), goto fail);
+            SBS_CATCH(sbscatlen(s, &next, 1), goto fail);
             break;
           }
         }
         break;
       default: {
-        SBS_CATCH(sbscatlen(str, f, 1), goto fail);
+        SBS_CATCH(sbscatlen(s, f, 1), goto fail);
         break;
       }
     }

--- a/sbs.c
+++ b/sbs.c
@@ -11,73 +11,62 @@
 #define SBS_NULLTERM(s) (s)->str[(s)->len] = '\0'
 
 #define SBS_CATCH(func, catch) \
-    do {                       \
-        int err = (func);      \
-        if (err != 0) {        \
-            catch;             \
-        }                      \
-    } while (0);
+  do {                         \
+    int err = (func);          \
+    if (err != 0) {            \
+      catch;                   \
+    }                          \
+  } while (0);
 
 // create a shallow copy to allow updates
 static void sbscpyshl(sbs *src, sbs *dst) {
-    dst->size = src->size;
-    dst->len = src->len;
-    dst->str = src->str;
+  dst->size = src->size;
+  dst->len = src->len;
+  dst->str = src->str;
 }
 
 sbs *sbsnewlen(sbs *s, const void *init, size_t initlen, char buffer[],
                size_t buffer_size) {
-    if (initlen >= buffer_size) {
-        return NULL;
-    }
-    s->str = buffer;
-    s->size = buffer_size;
-    s->len = initlen;
-    memcpy(s->str, init, initlen);
-    SBS_NULLTERM(s);
-    return s;
+  if (initlen >= buffer_size) {
+    return NULL;
+  }
+  s->str = buffer;
+  s->size = buffer_size;
+  s->len = initlen;
+  memcpy(s->str, init, initlen);
+  SBS_NULLTERM(s);
+  return s;
 }
 
 sbs *sbsnew(sbs *s, const char *init, char buffer[], size_t buffer_size) {
-    return sbsnewlen(s, init, strlen(init), buffer, buffer_size);
+  return sbsnewlen(s, init, strlen(init), buffer, buffer_size);
 }
 
 sbs *sbsempty(sbs *s, char *buffer, size_t buffer_size) {
-    // this will never fail
-    sbsnewlen(s, "", 0, buffer, buffer_size);
-    return s;
+  // this will never fail
+  sbsnewlen(s, "", 0, buffer, buffer_size);
+  return s;
 }
 
 sbs *sbsdup(sbs *s, sbs *d, char buffer[], size_t buffer_size) {
-    return sbsnewlen(d, s->str, s->len, buffer, buffer_size);
-}
-
-int sbsresize(sbs *s, char buffer[], size_t buffer_size) {
-    if (buffer_size <= s->len) {
-        return -1;
-    }
-    memcpy(buffer, s->str, s->len);
-    s->size = buffer_size;
-    s->str = buffer;
-    SBS_NULLTERM(s);
-    return 0;
+  return sbsnewlen(d, s->str, s->len, buffer, buffer_size);
 }
 
 void sbsupdatelen(sbs *s) { s->len = strlen(s->str); }
 
 void sbsclear(sbs *s) {
-    s->len = 0;
-    SBS_NULLTERM(s);
+  s->len = 0;
+  SBS_NULLTERM(s);
 }
 
 int sbscatlen(sbs *s, const void *t, size_t len) {
-    if (len >= sbsavail(s)) {
-        return -1;
-    }
-    memcpy(sbsend(s), t, len);
-    s->len += len;
-    SBS_NULLTERM(s);
-    return 0;
+  if (len >= sbsavail(s)) {
+    return -1;
+  }
+  memcpy(sbsend(s), t, len);
+  s->len += len;
+  SBS_NULLTERM(s);
+  return 0;
 }
 
 int sbscat(sbs *s, const char *t) { return sbscatlen(s, t, strlen(t)); }
@@ -85,13 +74,13 @@ int sbscat(sbs *s, const char *t) { return sbscatlen(s, t, strlen(t)); }
 int sbscatsbs(sbs *s, const sbs *t) { return sbscatlen(s, t->str, t->len); }
 
 int sbscpylen(sbs *s, const char *t, size_t len) {
-    if (len >= s->size) {
-        return -1;
-    }
-    s->len = len;
-    memcpy(s->str, t, len);
-    SBS_NULLTERM(s);
-    return 0;
+  if (len >= s->size) {
+    return -1;
+  }
+  s->len = len;
+  memcpy(s->str, t, len);
+  SBS_NULLTERM(s);
+  return 0;
 }
 
 int sbscpy(sbs *s, const char *t) { return sbscpylen(s, t, strlen(t)); }
@@ -99,89 +88,89 @@ int sbscpy(sbs *s, const char *t) { return sbscpylen(s, t, strlen(t)); }
 #ifndef SBS_NO_FORMAT
 /* Like sbscatprintf() but gets va_list instead of being variadic. */
 int sbscatvprintf(sbs *s, const char *fmt, va_list ap) {
-    size_t bufsize = sbsavail(s);
-    int n = vsnprintf(sbsend(s), bufsize, fmt, ap);
-    if (n >= bufsize) {
-        SBS_NULLTERM(s);
-        return -1;
-    }
-    s->len += n;
+  size_t bufsize = sbsavail(s);
+  int n = vsnprintf(sbsend(s), bufsize, fmt, ap);
+  if (n >= bufsize) {
     SBS_NULLTERM(s);
-    return 0;
+    return -1;
+  }
+  s->len += n;
+  SBS_NULLTERM(s);
+  return 0;
 }
 
 int sbscatprintf(sbs *s, const char *fmt, ...) {
-    va_list ap;
-    int t;
-    va_start(ap, fmt);
-    t = sbscatvprintf(s, fmt, ap);
-    va_end(ap);
-    return t;
+  va_list ap;
+  int t;
+  va_start(ap, fmt);
+  t = sbscatvprintf(s, fmt, ap);
+  va_end(ap);
+  return t;
 }
 #endif
 
 void sbstrim(sbs *s, const char *cset) {
-    char *start, *end, *sp, *ep;
-    size_t len;
+  char *start, *end, *sp, *ep;
+  size_t len;
 
-    sp = start = s->str;
-    ep = end = s->str + sbslen(s) - 1;
-    while (sp <= end && strchr(cset, *sp)) sp++;
-    while (ep > sp && strchr(cset, *ep)) ep--;
-    len = (sp > ep) ? 0 : ((ep - sp) + 1);
-    if (s->str != sp) memmove(s, sp, len);
-    s->len = len;
-    SBS_NULLTERM(s);
+  sp = start = s->str;
+  ep = end = s->str + sbslen(s) - 1;
+  while (sp <= end && strchr(cset, *sp)) sp++;
+  while (ep > sp && strchr(cset, *ep)) ep--;
+  len = (sp > ep) ? 0 : ((ep - sp) + 1);
+  if (s->str != sp) memmove(s, sp, len);
+  s->len = len;
+  SBS_NULLTERM(s);
 }
 
 void sbsrange(sbs *s, ssize_t start, ssize_t end) {
-    size_t newlen, len = sbslen(s);
+  size_t newlen, len = sbslen(s);
 
-    if (len == 0) return;
-    if (start < 0) {
-        start = len + start;
-        if (start < 0) start = 0;
+  if (len == 0) return;
+  if (start < 0) {
+    start = len + start;
+    if (start < 0) start = 0;
+  }
+  if (end < 0) {
+    end = len + end;
+    if (end < 0) end = 0;
+  }
+  newlen = (start > end) ? 0 : (end - start) + 1;
+  if (newlen != 0) {
+    if (start >= (ssize_t)len) {
+      newlen = 0;
+    } else if (end >= (ssize_t)len) {
+      end = len - 1;
+      newlen = (start > end) ? 0 : (end - start) + 1;
     }
-    if (end < 0) {
-        end = len + end;
-        if (end < 0) end = 0;
-    }
-    newlen = (start > end) ? 0 : (end - start) + 1;
-    if (newlen != 0) {
-        if (start >= (ssize_t)len) {
-            newlen = 0;
-        } else if (end >= (ssize_t)len) {
-            end = len - 1;
-            newlen = (start > end) ? 0 : (end - start) + 1;
-        }
-    } else {
-        start = 0;
-    }
-    if (start && newlen) memmove(s->str, s->str + start, newlen);
-    s->len = newlen;
-    SBS_NULLTERM(s);
+  } else {
+    start = 0;
+  }
+  if (start && newlen) memmove(s->str, s->str + start, newlen);
+  s->len = newlen;
+  SBS_NULLTERM(s);
 }
 
 /* Apply tolower() to every character of the sbs string 's'. */
 void sbstolower(sbs *s) {
-    for (size_t j = 0; j < sbslen(s); j++) s->str[j] = tolower(s->str[j]);
+  for (size_t j = 0; j < sbslen(s); j++) s->str[j] = tolower(s->str[j]);
 }
 
 /* Apply tolower() to every character of the sbs string 's'. */
 void sbstoupper(sbs *s) {
-    for (size_t j = 0; j < sbslen(s); j++) s->str[j] = toupper(s->str[j]);
+  for (size_t j = 0; j < sbslen(s); j++) s->str[j] = toupper(s->str[j]);
 }
 
 int sbscmp(const sbs *s1, const sbs *s2) {
-    size_t l1, l2, minlen;
-    int cmp;
+  size_t l1, l2, minlen;
+  int cmp;
 
-    l1 = sbslen(s1);
-    l2 = sbslen(s2);
-    minlen = (l1 < l2) ? l1 : l2;
-    cmp = memcmp(s1->str, s2->str, minlen);
-    if (cmp == 0) return l1 > l2 ? 1 : (l1 < l2 ? -1 : 0);
-    return cmp;
+  l1 = sbslen(s1);
+  l2 = sbslen(s2);
+  minlen = (l1 < l2) ? l1 : l2;
+  cmp = memcmp(s1->str, s2->str, minlen);
+  if (cmp == 0) return l1 > l2 ? 1 : (l1 < l2 ? -1 : 0);
+  return cmp;
 }
 
 /* Modify the string substituting all the occurrences of the set of
@@ -194,16 +183,16 @@ int sbscmp(const sbs *s1, const sbs *s2) {
  * The function returns the sbs string pointer, that is always the same
  * as the input pointer since no resize is needed. */
 void sbsmapchars(sbs *s, const char *from, const char *to, size_t setlen) {
-    size_t j, i, l = sbslen(s);
+  size_t j, i, l = sbslen(s);
 
-    for (j = 0; j < l; j++) {
-        for (i = 0; i < setlen; i++) {
-            if (s->str[j] == from[i]) {
-                s->str[j] = to[i];
-                break;
-            }
-        }
+  for (j = 0; j < l; j++) {
+    for (i = 0; i < setlen; i++) {
+      if (s->str[j] == from[i]) {
+        s->str[j] = to[i];
+        break;
+      }
     }
+  }
 }
 
 /* Helper for sbscatlonglong() doing the actual number -> string
@@ -214,63 +203,63 @@ void sbsmapchars(sbs *s, const char *from, const char *to, size_t setlen) {
  * representation stored at 's'. */
 #define SBS_LLSTR_SIZE 21
 static int sbsll2str(char *s, long long value) {
-    char *p, aux;
-    unsigned long long v;
-    size_t l;
+  char *p, aux;
+  unsigned long long v;
+  size_t l;
 
-    /* Generate the string representation, this method produces
-     * an reversed string. */
-    v = (value < 0) ? -value : value;
-    p = s;
-    do {
-        *p++ = '0' + (v % 10);
-        v /= 10;
-    } while (v);
-    if (value < 0) *p++ = '-';
+  /* Generate the string representation, this method produces
+   * an reversed string. */
+  v = (value < 0) ? -value : value;
+  p = s;
+  do {
+    *p++ = '0' + (v % 10);
+    v /= 10;
+  } while (v);
+  if (value < 0) *p++ = '-';
 
-    /* Compute length and add null term. */
-    l = p - s;
-    *p = '\0';
+  /* Compute length and add null term. */
+  l = p - s;
+  *p = '\0';
 
-    /* Reverse the string. */
+  /* Reverse the string. */
+  p--;
+  while (s < p) {
+    aux = *s;
+    *s = *p;
+    *p = aux;
+    s++;
     p--;
-    while (s < p) {
-        aux = *s;
-        *s = *p;
-        *p = aux;
-        s++;
-        p--;
-    }
-    return l;
+  }
+  return l;
 }
 #ifndef SBS_NO_FORMAT
 /* Identical sbsll2str(), but for unsigned long long type. */
 static int sbsull2str(char *s, unsigned long long v) {
-    char *p, aux;
-    size_t l;
+  char *p, aux;
+  size_t l;
 
-    /* Generate the string representation, this method produces
-     * an reversed string. */
-    p = s;
-    do {
-        *p++ = '0' + (v % 10);
-        v /= 10;
-    } while (v);
+  /* Generate the string representation, this method produces
+   * an reversed string. */
+  p = s;
+  do {
+    *p++ = '0' + (v % 10);
+    v /= 10;
+  } while (v);
 
-    /* Compute length and add null term. */
-    l = p - s;
-    *p = '\0';
+  /* Compute length and add null term. */
+  l = p - s;
+  *p = '\0';
 
-    /* Reverse the string. */
+  /* Reverse the string. */
+  p--;
+  while (s < p) {
+    aux = *s;
+    *s = *p;
+    *p = aux;
+    s++;
     p--;
-    while (s < p) {
-        aux = *s;
-        *s = *p;
-        *p = aux;
-        s++;
-        p--;
-    }
-    return l;
+  }
+  return l;
 }
 #endif
 /* Create an sbs string from a long long value. It is much faster than:
@@ -278,172 +267,171 @@ static int sbsull2str(char *s, unsigned long long v) {
  * sbscatprintf(sbsempty(),"%lld\n", value);
  */
 sbs *sbsfromlonglong(sbs *s, char buffer[64], long long value) {
-    char buf[SBS_LLSTR_SIZE];
-    int len = sbsll2str(buf, value);
-    return sbsnewlen(s, buf, len, buffer, 64);
+  char buf[SBS_LLSTR_SIZE];
+  int len = sbsll2str(buf, value);
+  return sbsnewlen(s, buf, len, buffer, 64);
 }
 
 /* Join an array of C strings using the specified separator (also a C string).
  * Returns the result as an sbs string. */
 int sbsjoin(sbs *s, const char **argv, int argc, const char *sep) {
-    int j;
-    sbs backup;
-    sbscpyshl(s, &backup);
+  int j;
+  sbs backup;
+  sbscpyshl(s, &backup);
 
-    for (j = 0; j < argc; j++) {
-        SBS_CATCH(sbscat(s, argv[j]), goto fail);
-        if (j != argc - 1) {
-            SBS_CATCH(sbscat(s, sep), goto fail);
-        }
+  for (j = 0; j < argc; j++) {
+    SBS_CATCH(sbscat(s, argv[j]), goto fail);
+    if (j != argc - 1) {
+      SBS_CATCH(sbscat(s, sep), goto fail);
     }
-    return 0;
+  }
+  return 0;
 fail:
-    sbscpyshl(&backup, s);
-    SBS_NULLTERM(s);  // fix the buffer
-    return -1;
+  sbscpyshl(&backup, s);
+  SBS_NULLTERM(s);  // fix the buffer
+  return -1;
 }
 
 int sbsjoinsbs(sbs *s, const sbs argv[], int argc, const char *sep,
                size_t seplen) {
-    int j;
-    sbs backup;
-    sbscpyshl(s, &backup);
+  int j;
+  sbs backup;
+  sbscpyshl(s, &backup);
 
-    for (j = 0; j < argc; j++) {
-        SBS_CATCH(sbscatsbs(s, &argv[j]), goto fail);
-        if (j != argc - 1) {
-            SBS_CATCH(sbscatlen(s, sep, seplen), goto fail);
-        }
+  for (j = 0; j < argc; j++) {
+    SBS_CATCH(sbscatsbs(s, &argv[j]), goto fail);
+    if (j != argc - 1) {
+      SBS_CATCH(sbscatlen(s, sep, seplen), goto fail);
     }
-    return 0;
+  }
+  return 0;
 fail:
-    sbscpyshl(&backup, s);
-    SBS_NULLTERM(s);  // fix the buffer
-    return -1;
+  sbscpyshl(&backup, s);
+  SBS_NULLTERM(s);  // fix the buffer
+  return -1;
 }
 #ifndef SBS_NO_FORMAT
 static int sbscatvfmt(sbs *s, char const *fmt, va_list ap) {
-    sbs backup;
-    sbscpyshl(s, &backup);
-    const char *f = fmt;
+  sbs backup;
+  sbscpyshl(s, &backup);
+  const char *f = fmt;
 
-    f = fmt; /* Next format specifier byte to process. */
-    while (*f) {
-        char next, *str;
-        size_t l;
-        long long num;
-        unsigned long long unum;
+  f = fmt; /* Next format specifier byte to process. */
+  while (*f) {
+    char next, *str;
+    size_t l;
+    long long num;
+    unsigned long long unum;
 
-        switch (*f) {
-            case '%':
-                next = *(f + 1);
-                f++;
-                switch (next) {
-                    case 's': {
-                        str = va_arg(ap, char *);
-                        SBS_CATCH(sbscat(s, str), goto fail);
-                        break;
-                    }
-                    case 'S': {
-                        sbs *tmp_sbs = va_arg(ap, sbs *);
-                        SBS_CATCH(sbscatsbs(s, tmp_sbs), goto fail);
-                        break;
-                    }
-                    case 'i':
-                    case 'I':
-                        if (next == 'i')
-                            num = va_arg(ap, int);
-                        else
-                            num = va_arg(ap, long long);
-                        {
-                            char numbuf[SBS_LLSTR_SIZE];
-                            l = sbsll2str(numbuf, num);
-                            SBS_CATCH(sbscatlen(s, numbuf, l), goto fail);
-                            break;
-                        }
-                        break;
-                    case 'u':
-                    case 'U':
-                        if (next == 'u')
-                            unum = va_arg(ap, unsigned int);
-                        else
-                            unum = va_arg(ap, unsigned long long);
-                        {
-                            char numbuf[SBS_LLSTR_SIZE];
-                            l = sbsull2str(numbuf, unum);
-                            SBS_CATCH(sbscatlen(s, numbuf, l), goto fail);
-                            break;
-                        }
-                        break;
-                    default: { /* Handle %% and generally %<unknown>. */
-                        SBS_CATCH(sbscatlen(s, &next, 1), goto fail);
-                        break;
-                    }
-                }
-                break;
-            default: {
-                SBS_CATCH(sbscatlen(s, f, 1), goto fail);
-                break;
-            }
-        }
+    switch (*f) {
+      case '%':
+        next = *(f + 1);
         f++;
+        switch (next) {
+          case 's': {
+            str = va_arg(ap, char *);
+            SBS_CATCH(sbscat(s, str), goto fail);
+            break;
+          }
+          case 'S': {
+            sbs *tmp_sbs = va_arg(ap, sbs *);
+            SBS_CATCH(sbscatsbs(s, tmp_sbs), goto fail);
+            break;
+          }
+          case 'i':
+          case 'I':
+            if (next == 'i')
+              num = va_arg(ap, int);
+            else
+              num = va_arg(ap, long long);
+            {
+              char numbuf[SBS_LLSTR_SIZE];
+              l = sbsll2str(numbuf, num);
+              SBS_CATCH(sbscatlen(s, numbuf, l), goto fail);
+              break;
+            }
+            break;
+          case 'u':
+          case 'U':
+            if (next == 'u')
+              unum = va_arg(ap, unsigned int);
+            else
+              unum = va_arg(ap, unsigned long long);
+            {
+              char numbuf[SBS_LLSTR_SIZE];
+              l = sbsull2str(numbuf, unum);
+              SBS_CATCH(sbscatlen(s, numbuf, l), goto fail);
+              break;
+            }
+            break;
+          default: { /* Handle %% and generally %<unknown>. */
+            SBS_CATCH(sbscatlen(s, &next, 1), goto fail);
+            break;
+          }
+        }
+        break;
+      default: {
+        SBS_CATCH(sbscatlen(s, f, 1), goto fail);
+        break;
+      }
     }
-    return 0;
+    f++;
+  }
+  return 0;
 fail:
-    sbscpyshl(&backup, s);
-    SBS_NULLTERM(s);  // fix the buffer
-    return -1;
+  sbscpyshl(&backup, s);
+  SBS_NULLTERM(s);  // fix the buffer
+  return -1;
 }
 
 int sbscatfmt(sbs *s, char const *fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    int err = sbscatvfmt(s, fmt, ap);
-    va_end(ap);
-    return err;
+  va_list ap;
+  va_start(ap, fmt);
+  int err = sbscatvfmt(s, fmt, ap);
+  va_end(ap);
+  return err;
 }
 
 int sbscatrepr(sbs *s, const char *p, size_t len) {
-    sbs backup;
-    sbscpyshl(s, &backup);
-    SBS_CATCH(sbscatlen(s, "\"", 1), goto fail);
-    while (len--) {
-        switch (*p) {
-            case '\\':
-            case '"':
-                SBS_CATCH(sbscatprintf(s, "\\%c", *p), goto fail);
-                break;
-            case '\n':
-                SBS_CATCH(sbscatlen(s, "\\n", 2), goto fail);
-                break;
-            case '\r':
-                SBS_CATCH(sbscatlen(s, "\\r", 2), goto fail);
-                break;
-            case '\t':
-                SBS_CATCH(sbscatlen(s, "\\t", 2), goto fail);
-                break;
-            case '\a':
-                SBS_CATCH(sbscatlen(s, "\\a", 2), goto fail);
-                break;
-            case '\b':
-                SBS_CATCH(sbscatlen(s, "\\b", 2), goto fail);
-                break;
-            default:
-                if (isprint(*p)) {
-                    SBS_CATCH(sbscatprintf(s, "%c", *p), goto fail);
-                } else {
-                    SBS_CATCH(sbscatprintf(s, "\\x%02x", (unsigned char)*p),
-                              goto fail);
-                }
-                break;
+  sbs backup;
+  sbscpyshl(s, &backup);
+  SBS_CATCH(sbscatlen(s, "\"", 1), goto fail);
+  while (len--) {
+    switch (*p) {
+      case '\\':
+      case '"':
+        SBS_CATCH(sbscatprintf(s, "\\%c", *p), goto fail);
+        break;
+      case '\n':
+        SBS_CATCH(sbscatlen(s, "\\n", 2), goto fail);
+        break;
+      case '\r':
+        SBS_CATCH(sbscatlen(s, "\\r", 2), goto fail);
+        break;
+      case '\t':
+        SBS_CATCH(sbscatlen(s, "\\t", 2), goto fail);
+        break;
+      case '\a':
+        SBS_CATCH(sbscatlen(s, "\\a", 2), goto fail);
+        break;
+      case '\b':
+        SBS_CATCH(sbscatlen(s, "\\b", 2), goto fail);
+        break;
+      default:
+        if (isprint(*p)) {
+          SBS_CATCH(sbscatprintf(s, "%c", *p), goto fail);
+        } else {
+          SBS_CATCH(sbscatprintf(s, "\\x%02x", (unsigned char)*p), goto fail);
         }
-        p++;
+        break;
     }
-    SBS_CATCH(sbscatlen(s, "\"", 1), goto fail);
-    return 0;
+    p++;
+  }
+  SBS_CATCH(sbscatlen(s, "\"", 1), goto fail);
+  return 0;
 fail:
-    sbscpyshl(&backup, s);
-    SBS_NULLTERM(s);  // fix string buffer
-    return -1;
+  sbscpyshl(&backup, s);
+  SBS_NULLTERM(s);  // fix string buffer
+  return -1;
 }
 #endif

--- a/sbs.h
+++ b/sbs.h
@@ -21,22 +21,22 @@ typedef struct {
 
 // Properties
 
-static inline size_t sbslen(const sbs str) {
-  sbshdr *s = to_sbshdr(str);
-  return s->len;
+static inline size_t sbslen(const sbs s) {
+  sbshdr *h = to_sbshdr(s);
+  return h->len;
 }
 
-static inline size_t sbssize(const sbs str) {
-  sbshdr *s = to_sbshdr(str);
-  return s->size;
+static inline size_t sbssize(const sbs s) {
+  sbshdr *h = to_sbshdr(s);
+  return h->size;
 }
-static inline size_t sbsavail(const sbs str) {
-  sbshdr *s = to_sbshdr(str);
-  return s->size - s->len;
+static inline size_t sbsavail(const sbs s) {
+  sbshdr *h = to_sbshdr(s);
+  return h->size - h->len;
 }
-static inline char *sbsend(const sbs str) {
-  sbshdr *s = to_sbshdr(str);
-  return s->str + s->len;
+static inline char *sbsend(const sbs s) {
+  sbshdr *h = to_sbshdr(s);
+  return h->str + h->len;
 }
 
 // Initialization

--- a/sbs.h
+++ b/sbs.h
@@ -8,9 +8,9 @@
 #include <sys/types.h>
 
 typedef struct {
-    char *str;
-    size_t len;
-    size_t size;
+  char *str;
+  size_t len;
+  size_t size;
 } sbs;
 
 // Properties
@@ -25,7 +25,7 @@ static inline char *sbsend(const sbs *s) { return s->str + s->len; }
 sbs *sbsnewlen(sbs *s, const void *init, size_t initlen, char buffer[],
                size_t buffer_size);
 #define SBSNEWLEN(init, initlen, size) \
-    sbsnewlen(&(sbs){0}, init, initlen, (char[size]){0}, size)
+  sbsnewlen(&(sbs){0}, init, initlen, (char[size]){0}, size)
 sbs *sbsnew(sbs *s, const char *init, char buffer[], size_t buffer_size);
 #define SBSNEW(init, size) sbsnew(&(sbs){0}, init, (char[size]){0}, size)
 sbs *sbsempty(sbs *s, char buffer[], size_t buffer_size);
@@ -78,12 +78,10 @@ int sbsjoinsbs(sbs *s, const sbs argv[], int argc, const char *sep,
                size_t seplen);
 
 // escape hatch
-int sbsresize(sbs *s, char buffer[], size_t buffer_size);
-#define SBSRESIZE(s, size) sbsresize(s, (char[size]){}, size)
 static inline void sbssetlen(sbs *s, size_t len) {
-    if (s->len >= s->size) return;
-    s->len = len;
-    s->str[s->len] = '\0';  // null terminate in case
+  if (s->len >= s->size) return;
+  s->len = len;
+  s->str[s->len] = '\0';  // null terminate in case
 }
 void sbsupdatelen(sbs *s);
 

--- a/test-sbs.c
+++ b/test-sbs.c
@@ -6,117 +6,117 @@
 #include "tinytest.h"
 
 void test_sbsnewlen() {
-    const char raw_data[] = {65, 65, 65, 0x0, 23, 32};
-    sbs* data = SBSNEWLEN(raw_data, sizeof(raw_data), 512);
-    ASSERT_EQUALS(sbslen(data), sizeof(raw_data));
-    ASSERT_EQUALS(raw_data[4], data->str[4]);  // check it went pass null-term
+  const char raw_data[] = {65, 65, 65, 0x0, 23, 32};
+  sbs data = SBSNEWLEN(raw_data, sizeof(raw_data), 512);
+  ASSERT_EQUALS(sbslen(data), sizeof(raw_data));
+  ASSERT_EQUALS(raw_data[4], data[4]);  // check it went pass null-term
 }
 
 void test_sbsnew() {
-    sbs* text = SBSNEW("this is a test", 512);
-    ASSERT_STRING_EQUALS(sbsstr(text), "this is a test");
-    sbs* fail = SBSNEW("this is too long", 16);
-    ASSERT_EQUALS(NULL, fail);
-    sbs* canfit = SBSNEW("this is just right", 19);
-    ASSERT_STRING_EQUALS(sbsstr(canfit), "this is just right");
+  sbs text = SBSNEW("this is a test", 512);
+  ASSERT_STRING_EQUALS(text, "this is a test");
+  sbs fail = SBSNEW("this is too long", 16);
+  ASSERT_EQUALS(NULL, fail);
+  sbs canfit = SBSNEW("this is just right", 19);
+  ASSERT_STRING_EQUALS(canfit, "this is just right");
 }
 
 void test_sbsempty() {
-    sbs* text = SBSEMPTY(512);
-    ASSERT_EQUALS(sbslen(text), 0);
-    ASSERT_EQUALS(text->str[0], '\0');
-    ASSERT_EQUALS(512, sbssize(text));
+  sbs text = SBSEMPTY(512);
+  ASSERT_EQUALS(sbslen(text), 0);
+  ASSERT_EQUALS(text[0], '\0');
+  ASSERT_EQUALS(512, sbssize(text));
 }
 
 void test_sbsdup() {
-    sbs* text = SBS512("this is test text");
-    sbs* text2 = SBSDUP(text, 512);
-    sbscat(text, " newer text");
-    // ensure they are separate buffers
-    ASSERT_STRING_EQUALS("this is test text", sbsstr(text2));
-    sbs* fail = SBSDUP(text, 17);
-    ASSERT_EQUALS(NULL, fail);
+  sbs text = SBS512("this is test text");
+  sbs text2 = SBSDUP(text, 512);
+  sbscat(text, " newer text");
+  // ensure they are separate buffers
+  ASSERT_STRING_EQUALS("this is test text", text2);
+  sbs fail = SBSDUP(text, 17);
+  ASSERT_EQUALS(NULL, fail);
 }
 
 void test_sbscat() {
-    sbs* text = SBS512("first");
-    sbscat(text, "|second");
-    ASSERT_STRING_EQUALS("first|second", sbsstr(text));
-    sbs* small = SBSNEW("", 12);
-    sbscat(small, "first");
-    int err = sbscat(small, "this text is way too long");
-    ASSERT("Buffer overflow check", err != 0);
-    sbscat(small, " ok");
-    ASSERT_STRING_EQUALS(sbsstr(small), "first ok");
+  sbs text = SBS512("first");
+  sbscat(text, "|second");
+  ASSERT_STRING_EQUALS("first|second", text);
+  sbs small = SBSNEW("", 12);
+  sbscat(small, "first");
+  int err = sbscat(small, "this text is way too long");
+  ASSERT("Buffer overflow check", err != 0);
+  sbscat(small, " ok");
+  ASSERT_STRING_EQUALS(small, "first ok");
 }
 
 void test_sbscatsbs() {
-    sbs* text = SBS512("first");
-    sbscat(text, "|second");
-    ASSERT_STRING_EQUALS("first|second", sbsstr(text));
-    sbs* combined = SBS512("zero|");
-    sbscatsbs(combined, text);
-    ASSERT_STRING_EQUALS(sbsstr(combined), "zero|first|second");
+  sbs text = SBS512("first");
+  sbscat(text, "|second");
+  ASSERT_STRING_EQUALS("first|second", text);
+  sbs combined = SBS512("zero|");
+  sbscatsbs(combined, text);
+  ASSERT_STRING_EQUALS(combined, "zero|first|second");
 }
 
 void test_sbscpy() {
-    sbs* text = SBS512("text to replace");
-    sbscpy(text, "newer text");
-    ASSERT_STRING_EQUALS("newer text", sbsstr(text));
-    sbs* fail = SBSEMPTY(4);
-    int err = sbscpy(fail, "too long text");
-    ASSERT("overflow copy", err != 0);
-    sbscpy(fail, "ok");
-    ASSERT_STRING_EQUALS("ok", sbsstr(fail));
+  sbs text = SBS512("text to replace");
+  sbscpy(text, "newer text");
+  ASSERT_STRING_EQUALS("newer text", text);
+  sbs fail = SBSEMPTY(4);
+  int err = sbscpy(fail, "too long text");
+  ASSERT("overflow copy", err != 0);
+  sbscpy(fail, "ok");
+  ASSERT_STRING_EQUALS("ok", fail);
 }
 
 void test_sbsfromlonglong() {
-    sbs* nums;
-    long long val;
-    nums = SBSFROMLL(23);
-    ASSERT_STRING_EQUALS("23", sbsstr(nums));
-    nums = SBSFROMLL(LLONG_MAX);
-    val = strtoll(sbsstr(nums), NULL, 10);
-    ASSERT_EQUALS(LLONG_MAX, val);
-    nums = SBSFROMLL(LLONG_MIN);
-    val = strtoll(sbsstr(nums), NULL, 10);
-    ASSERT_EQUALS(LLONG_MIN, val);
+  sbs nums;
+  long long val;
+  nums = SBSFROMLL(23);
+  ASSERT_STRING_EQUALS("23", nums);
+  nums = SBSFROMLL(LLONG_MAX);
+  val = strtoll(nums, NULL, 10);
+  ASSERT_EQUALS(LLONG_MAX, val);
+  nums = SBSFROMLL(LLONG_MIN);
+  val = strtoll(nums, NULL, 10);
+  ASSERT_EQUALS(LLONG_MIN, val);
 }
 #ifndef SBS_NO_FORMAT
 void test_sbscatprintf() {
-    sbs* text = SBS512("");
-    sbscatprintf(text, "%d %d", 23, 32);
-    ASSERT_STRING_EQUALS("23 32", sbsstr(text));
+  sbs text = SBS512("");
+  sbscatprintf(text, "%d %d", 23, 32);
+  ASSERT_STRING_EQUALS("23 32", text);
 
-    sbs* fail = SBSNEW("original", 24);
-    int err = sbscatprintf(fail, "%s", "this too long123");
-    ASSERT("fail too long", err != 0);
-    sbscatprintf(fail, "%s", "this is fine123");
-    ASSERT_STRING_EQUALS("originalthis is fine123", sbsstr(fail));
+  sbs fail = SBSNEW("original", 24);
+  int err = sbscatprintf(fail, "%s", "this too long123");
+  ASSERT("fail too long", err != 0);
+  sbscatprintf(fail, "%s", "this is fine123");
+  ASSERT_STRING_EQUALS("originalthis is fine123", fail);
 }
 
 void test_sbscatfmt() {
-    sbs* text = SBS512("");
-    sbscatfmt(text, "%s %S %i %I %u %U%%", "normal", SBS64("test"), 123,
-              (long long)456, (unsigned)789, (unsigned long long)987);
-    ASSERT_STRING_EQUALS("normal test 123 456 789 987%", sbsstr(text));
+  sbs text = SBS512("");
+  sbscatfmt(text, "%s %S %i %I %u %U%%", "normal", SBS64("test"), 123,
+            (long long)456, (unsigned)789, (unsigned long long)987);
+  ASSERT_STRING_EQUALS("normal test 123 456 789 987%", text);
 
-    // text = SBSNEW("", 32);
-    // sbscatfmt(text, "%s ")
+  // text = SBSNEW("", 32);
+  // sbscatfmt(text, "%s ")
 }
 #endif
 int main() {
-    RUN(test_sbsnewlen);
-    RUN(test_sbsnew);
-    RUN(test_sbsempty);
-    RUN(test_sbsdup);
-    RUN(test_sbscat);
-    RUN(test_sbscatsbs);
-    RUN(test_sbscpy);
-    RUN(test_sbsfromlonglong);
+  RUN(test_sbsnewlen);
+  RUN(test_sbsnew);
+  RUN(test_sbsempty);
+  RUN(test_sbsdup);
+  RUN(test_sbscat);
+  RUN(test_sbscatsbs);
+  RUN(test_sbscpy);
+  RUN(test_sbsfromlonglong);
 #ifndef SBS_NO_FORMAT
-    RUN(test_sbscatprintf);
-    RUN(test_sbscatfmt);
+  RUN(test_sbscatprintf);
+  RUN(test_sbscatfmt);
 #endif
-    return TEST_REPORT();
+  return TEST_REPORT();
 }


### PR DESCRIPTION
Use prefix header so that it behaves even more like sds. Users pass in a string buffer and it will take some space for a header